### PR TITLE
Iterate package semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-hook-fixtures",
-  "version": "1.0.1-beta",
+  "version": "1.0.2",
   "description": "Automatically install database fixtures with relations to your database when you lift Sails",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
At present, during build, there is a Git error that occurs for this package:

```
 ---> Running in abd784d8e739
Unhandled rejection Error: Command failed: /usr/bin/git checkout 23e6ba981e33862b8a540be8fb11132fe87eede1
fatal: reference is not a tree: 23e6ba981e33862b8a540be8fb11132fe87eede1
```

I believe (have not tested) by simply updating the version of this package we can include/target the latest version. I suspect there may be a quirk involved in our case where there are many versions of this package  @ version `1.0.1-beta`.

Note: this change should coincide with updating the package version in api's package.json